### PR TITLE
Add verifyJWT middleware to employees route

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,8 +39,8 @@ app.use('/auth', require('./routes/auth'));
 app.use('/refresh', require('./routes/refresh'));
 app.use('/logout', require('./routes/logout'));
 
-app.use(verifyJWT);
-app.use('/employees', require('./routes/api/employees'));
+//adding verifyJWT middleware to only /employees route
+app.use('/employees', [verifyJWT, require('./routes/api/employees')]);
 
 app.all('*', (req, res) => {
     res.status(404);


### PR DESCRIPTION
### **Pull Request Description**  

#### **Problem**  
The `verifyJWT` middleware was being applied globally, causing it to intercept all requests, including those to nonexistent routes. This resulted in "Unauthorized" errors being returned for such routes instead of the correct "404 Not Found" response.  

#### **Solution**  
The `verifyJWT` middleware has been restricted to only the `/employees` route by using the following syntax:  
```javascript
app.use('/employees', [verifyJWT, require('./routes/api/employees')]);
```  
This ensures that the middleware applies authentication checks only for the `/employees` route and does not interfere with other routes, including the 404 handler.  

#### **Impact**  
- Requests to protected routes like `/employees` will still require valid authentication.  
- Nonexistent routes now correctly return a "404 Not Found" response instead of an "Unauthorized" error.  

#### **Testing**  
- Verified that protected routes (`/employees`) return "Unauthorized" if JWT is missing or invalid.  
- Verified that nonexistent routes return "404 Not Found" without being intercepted by the `verifyJWT` middleware.  